### PR TITLE
feat : QA에서 나온 간격, 폰트, 행간 등 문제 수정

### DIFF
--- a/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/home/PostAdapter.kt
+++ b/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/home/PostAdapter.kt
@@ -48,7 +48,7 @@ class PostAdapter(
         fun bind(post: Post) = with(binding) {
             this@PostViewHolder.post = post
             tvTitle.text = post.title
-            tvContent.text = post.content
+            tvContent.text = post.content.replace("\n", " ")
             tvView.text = post.viewCount.formatNumberWithComma()
             tvLike.text = post.likeCount.formatNumberWithComma()
             binding.ivImage.isGone = post.imageUrl.isEmpty()

--- a/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/home/PostItemDecoration.kt
+++ b/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/home/PostItemDecoration.kt
@@ -10,7 +10,7 @@ import com.silvertown.android.dailyphrase.presentation.extensions.dpToPx
 class PostItemDecoration(val context: Context) : RecyclerView.ItemDecoration() {
     private val dividerHeight = 1.dpToPx(context)
     private val dividerMargin = 16.dpToPx(context)
-    private val headerMargin = 16.dpToPx(context)
+    private val headerMargin = 0.dpToPx(context)
     private val footerMargin = 16.dpToPx(context)
     private val dividerColor = 0xFFF2F3F6.toInt() // color.xml 생기면 수정
 
@@ -32,13 +32,11 @@ class PostItemDecoration(val context: Context) : RecyclerView.ItemDecoration() {
 
         if (position == 0) {
             outRect.top = headerMargin
-        }
-
-        if (position == itemCount - 1) {
+        } else if (position == itemCount - 1) {
             outRect.bottom = footerMargin
+        } else {
+            outRect.bottom = dividerHeight
         }
-
-        outRect.bottom = dividerHeight
     }
 
     override fun onDraw(c: Canvas, parent: RecyclerView, state: RecyclerView.State) {

--- a/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/mypage/non_login/NonLoginScreen.kt
+++ b/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/mypage/non_login/NonLoginScreen.kt
@@ -37,7 +37,7 @@ fun NonLoginScreen(
         modifier = modifier
             .fillMaxSize(),
         navigateToBack = navigateToBack,
-        onClickKaKaoLogin = onClickKaKaoLogin
+        onClickKaKaoLogin = onClickKaKaoLogin,
     )
 }
 
@@ -60,17 +60,17 @@ private fun Content(
                         style = TextStyle(
                             fontSize = 22.sp,
                             fontFamily = pretendardFamily,
-                            fontWeight = FontWeight.Medium
+                            fontWeight = FontWeight.Medium,
                         ),
-                        color = colorResource(id = R.color.black)
+                        color = colorResource(id = R.color.black),
                     )
                 },
             )
-        }
+        },
     ) {
         NonLoginBody(
             modifier = Modifier,
-            onClickKaKaoLogin = onClickKaKaoLogin
+            onClickKaKaoLogin = onClickKaKaoLogin,
         )
     }
 }
@@ -83,22 +83,23 @@ private fun NonLoginBody(
     Column(
         modifier = modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
-            text = stringResource(id = R.string.non_login_description),
+            text = stringResource(id = R.string.login_and_share_message),
             style = TextStyle(
                 fontSize = 28.sp,
                 fontFamily = pretendardFamily,
-                fontWeight = FontWeight.SemiBold
+                fontWeight = FontWeight.SemiBold,
+                lineHeight = 36.sp,
             ),
-            textAlign = TextAlign.Center
+            textAlign = TextAlign.Center,
         )
-        Spacer(modifier = Modifier.height(10.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
         KaKaoLoginButton(
             modifier = Modifier.widthIn(max = 240.dp),
-            onClickKaKaoLogin = onClickKaKaoLogin
+            onClickKaKaoLogin = onClickKaKaoLogin,
         )
     }
 }

--- a/presentation/src/main/res/layout/fragment_home.xml
+++ b/presentation/src/main/res/layout/fragment_home.xml
@@ -44,7 +44,7 @@
             android:id="@+id/iv_profile"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="6dp"
+            android:layout_marginEnd="4dp"
             android:padding="10dp"
             android:src="@drawable/ic_profile"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/presentation/src/main/res/layout/item_post.xml
+++ b/presentation/src/main/res/layout/item_post.xml
@@ -14,6 +14,7 @@
         android:text="자식사랑 내리사랑"
         android:textColor="@color/black"
         android:textSize="20sp"
+        android:lineSpacingExtra="3.5dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -25,8 +26,9 @@
         android:fontFamily="@font/pretendard_regular"
         android:textColor="@color/gray"
         android:textSize="16sp"
-        android:maxLines="3"
+        android:maxLines="2"
         android:ellipsize="end"
+        android:lineSpacingExtra="3.5dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tv_title"
         tools:text="어느날 시계를 보다가 문득 이런 생각을 한 적이 있습니다. 성급한 사람, 무덤덤한 사람, 아무 생각이 없는 사람" />
@@ -69,6 +71,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:fontFamily="@font/pretendard_regular"
+            android:layout_marginStart="2dp"
             android:text="@string/bookmark"
             android:textColor="@color/gray"
             android:textSize="14sp"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -9,10 +9,9 @@
     <string name="share_app">앱 공유하기</string>
     <string name="leave_review">앱 리뷰 남기기</string>
     <string name="logout">로그아웃</string>
-    <string name="login_and_share_message">로그인하고\n글귀를 공유해 보세요.</string>
+    <string name="login_and_share_message">로그인하고\n글귀를 공유해 보세요</string>
     <string name="login_and_like_message">로그인하고\n글귀에 관심을 표현하세요.</string>
     <string name="login_and_bookmark_message">로그인하고\n글귀를 관리해 보세요.</string>
-    <string name="non_login_description">로그인하고\n내 정보를 관리해 보세요.</string>
     <string name="unsubscribe_service">서비스 탈퇴</string>
     <string name="message_before_leaving">탈퇴하기 전에 꼭 확인해주세요.</string>
     <string name="unsubscribe_message_title_1">즐겨찾는 글귀가 모두 사라져요.</string>


### PR DESCRIPTION
- [x] 홈에서 프로필 아이콘 marginEnd 6dp -> 4dp
- [x] 게시물 타이틀, 내용 행간 적용
- [x] "로그인하고 글귀를 공유해 보세요" 텍스트가 피그마랑 다른거 수정
- [x] "로그인하고 글귀를 공유해 보세요" 텍스트 행간 적용
- [x] "로그인하고 글귀를 공유해 보세요" 텍스트와 카카오 로그인 사이 간격 10dp -> 16dp
- [ ] 게시물 이미지 radius 16dp -> 10dp (이거 10으로 주니까 피그마랑 너무 다르게 보여서 좀 이상함. 나중에 확인해봐야할듯)
- [x] 게시물 리스트 헤더 16dp -> 0dp
- [x] 게시물 리스트 Footer 적용 안되고 있는 버그 수정