### PR TITLE
fix-85 : Room DB Entity 이슈

### DIFF
--- a/data/src/main/kotlin/com/silvertown/android/dailyphrase/data/database/DaosModule.kt
+++ b/data/src/main/kotlin/com/silvertown/android/dailyphrase/data/database/DaosModule.kt
@@ -1,6 +1,5 @@
 package com.silvertown.android.dailyphrase.data.database
 
-import com.silvertown.android.dailyphrase.data.database.PostDatabase
 import com.silvertown.android.dailyphrase.data.database.dao.PostDao
 import dagger.Module
 import dagger.Provides

--- a/data/src/main/kotlin/com/silvertown/android/dailyphrase/data/database/DatabaseModule.kt
+++ b/data/src/main/kotlin/com/silvertown/android/dailyphrase/data/database/DatabaseModule.kt
@@ -15,9 +15,8 @@ object DatabaseModule {
     @Provides
     @Singleton
     fun providesPostDatabase(@ApplicationContext context: Context): PostDatabase =
-        Room.databaseBuilder(
+        Room.inMemoryDatabaseBuilder(
             context,
             PostDatabase::class.java,
-            "post-database"
         ).build()
 }

--- a/data/src/main/kotlin/com/silvertown/android/dailyphrase/data/database/model/PostEntity.kt
+++ b/data/src/main/kotlin/com/silvertown/android/dailyphrase/data/database/model/PostEntity.kt
@@ -8,7 +8,8 @@ import com.silvertown.android.dailyphrase.domain.model.Post
     tableName = "post_source"
 )
 data class PostEntity(
-    @PrimaryKey
+    @PrimaryKey(autoGenerate = true)
+    val postId: Long = 0,
     val phraseId: Long,
     val title: String,
     val content: String,


### PR DESCRIPTION
## 구현

Paging3 구현 시 RemoteMediator를 사용하여 로컬 데이터베이스에 데이터를 캐싱하여 원천 데이터소스를 로컬에서 관리하도록 구현

## 이슈

Room DB는 PrimaryKey를 오름차순으로 항상 관리하기에, 서버로부터 항상 내림차순의 phraseId를 받는 정책의 특성 상 @Query("SELECT * FROM post_source ORDER BY phraseId DESC")를 해줘야 했고, 글귀 목록 페이징 시 순간적인 위치 변화가 발생

## 해결

autoGenerate를 위한 postId 필드를 추가

항상 홈의 글귀 목록은 리프래시되고 항상 갱신되며 달라지는 데이터이기에 autoGenerate의 값이 끊임없이 증가됨.

이에 inMemoryDB로 변경하여 데이터 관리