### PR TITLE
QT 3차 수정사항 반영

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         tools:targetApi="31">
         <activity
             android:name=".presentation.MainActivity"
+            android:screenOrientation="portrait"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/data/src/main/kotlin/com/silvertown/android/dailyphrase/data/repository/MemberRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/silvertown/android/dailyphrase/data/repository/MemberRepositoryImpl.kt
@@ -46,7 +46,6 @@ class MemberRepositoryImpl @Inject constructor(
             .toResultModel { it.result?.toDomainModel() }
 
     override suspend fun deleteMember(): Result<Member> {
-        deleteAccessToken()
         return memberDataSource
             .deleteMember(memberPreferencesDataSource.getMemberId())
             .toResultModel { it.result?.toDomainModel() }

--- a/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/component/MyPageProfile.kt
+++ b/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/component/MyPageProfile.kt
@@ -50,7 +50,7 @@ private fun ProfileHeader(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(top = 20.dp, bottom = 5.dp),
+            .padding(top = 16.dp),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {

--- a/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/bookmark/BookmarkAdapter.kt
+++ b/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/bookmark/BookmarkAdapter.kt
@@ -48,31 +48,45 @@ class BookmarkAdapter(
 
         fun bind(post: Post) = with(binding) {
             this@BookmarkViewHolder.post = post
+            val context = itemView.context
+            
             tvTitle.text = post.title.replace("\n", " ")
             tvContent.text = post.content.replace("\n", " ")
             tvView.text = post.viewCount.formatNumberWithComma()
             tvLike.text = post.likeCount.formatNumberWithComma()
-            tvBookmark.setTextColor(
-                if (post.isFavorite) {
-                    ContextCompat.getColor(itemView.context, R.color.black)
-                } else {
-                    ContextCompat.getColor(itemView.context, R.color.gray)
-                }
-            )
-            tvBookmark.typeface = if (post.isFavorite) {
-                ResourcesCompat.getFont(itemView.context, R.font.pretendard_medium)
+            if (post.isFavorite) {
+                R.color.black
             } else {
-                ResourcesCompat.getFont(itemView.context, R.font.pretendard_regular)
+                R.color.gray
+            }.also { colorResId ->
+                tvBookmark.setTextColor(ContextCompat.getColor(context, colorResId))
             }
+
+            if (post.isFavorite) {
+                ResourcesCompat.getFont(context, R.font.pretendard_medium)
+            } else {
+                ResourcesCompat.getFont(context, R.font.pretendard_regular)
+            }.also { typeface ->
+                tvBookmark.typeface = typeface
+            }
+
+            if (post.isFavorite) {
+                R.drawable.ic_bookmark_fill_60
+            } else {
+                R.drawable.ic_bookmark_24
+            }.also { drawableRes ->
+                ivBookmark.setImageResource(drawableRes)
+            }
+
+            if (post.isLike) {
+                R.drawable.ic_like_fill_60
+            } else {
+                R.drawable.ic_like_60
+            }.also { drawableRes ->
+                ivLike.setImageResource(drawableRes)
+            }
+
             ivImage.isGone = post.imageUrl.isEmpty()
-
-            val bookmarkRes =
-                if (post.isFavorite) R.drawable.ic_bookmark_fill_60 else R.drawable.ic_bookmark_24
-            ivBookmark.setImageResource(bookmarkRes)
-
-            val likeRes = if (post.isLike) R.drawable.ic_like_fill_60 else R.drawable.ic_like_60
-            ivLike.setImageResource(likeRes)
-
             Glide.with(itemView)
                 .load(post.imageUrl)
                 .transform(CenterCrop(), RoundedCorners(16))

--- a/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/bookmark/BookmarkAdapter.kt
+++ b/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/bookmark/BookmarkAdapter.kt
@@ -42,6 +42,7 @@ class BookmarkAdapter(
             binding.clBookmark.setOnClickListener {
                 onClickBookmark(post.phraseId)
             }
+            // View 아이콘 클릭 시 root영역에 대한 클릭리스너와 중복을 피하기 위한 임시 리스너 활성
             binding.clView.setOnClickListener { }
         }
 

--- a/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/bookmark/BookmarkAdapter.kt
+++ b/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/bookmark/BookmarkAdapter.kt
@@ -2,6 +2,9 @@ package com.silvertown.android.dailyphrase.presentation.ui.bookmark
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.core.content.res.ResourcesCompat
+import androidx.core.view.isGone
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -39,26 +42,40 @@ class BookmarkAdapter(
             binding.clBookmark.setOnClickListener {
                 onClickBookmark(post.phraseId)
             }
+            binding.clView.setOnClickListener { }
         }
 
         fun bind(post: Post) = with(binding) {
             this@BookmarkViewHolder.post = post
-            tvTitle.text = post.title
-            tvContent.text = post.content
+            tvTitle.text = post.title.replace("\n", " ")
+            tvContent.text = post.content.replace("\n", " ")
             tvView.text = post.viewCount.formatNumberWithComma()
             tvLike.text = post.likeCount.formatNumberWithComma()
+            tvBookmark.setTextColor(
+                if (post.isFavorite) {
+                    ContextCompat.getColor(itemView.context, R.color.black)
+                } else {
+                    ContextCompat.getColor(itemView.context, R.color.gray)
+                }
+            )
+            tvBookmark.typeface = if (post.isFavorite) {
+                ResourcesCompat.getFont(itemView.context, R.font.pretendard_medium)
+            } else {
+                ResourcesCompat.getFont(itemView.context, R.font.pretendard_regular)
+            }
+            ivImage.isGone = post.imageUrl.isEmpty()
+
+            val bookmarkRes =
+                if (post.isFavorite) R.drawable.ic_bookmark_fill_60 else R.drawable.ic_bookmark_24
+            ivBookmark.setImageResource(bookmarkRes)
+
+            val likeRes = if (post.isLike) R.drawable.ic_like_fill_60 else R.drawable.ic_like_60
+            ivLike.setImageResource(likeRes)
 
             Glide.with(itemView)
                 .load(post.imageUrl)
                 .transform(CenterCrop(), RoundedCorners(16))
-                .into(binding.ivImage)
-
-            val bookmarkRes =
-                if (post.isFavorite) R.drawable.ic_bookmark_fill_60 else R.drawable.ic_bookmark_24
-            binding.ivBookmark.setImageResource(bookmarkRes)
-
-            val likeRes = if (post.isLike) R.drawable.ic_like_fill_60 else R.drawable.ic_like_60
-            binding.ivLike.setImageResource(likeRes)
+                .into(ivImage)
         }
     }
 

--- a/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/bookmark/BookmarkFragment.kt
+++ b/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/bookmark/BookmarkFragment.kt
@@ -97,8 +97,8 @@ class BookmarkFragment : BaseFragment<FragmentBookmarkBinding>(FragmentBookmarkB
         viewModel.getBookmarks()
     }
 
-    override fun onPause() {
-        super.onPause()
+    override fun onStop() {
+        super.onStop()
         setStatusBarColor(R.color.white)
     }
 

--- a/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/bookmark/BookmarkFragment.kt
+++ b/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/bookmark/BookmarkFragment.kt
@@ -2,14 +2,17 @@ package com.silvertown.android.dailyphrase.presentation.ui.bookmark
 
 import android.os.Bundle
 import android.view.View
+import android.view.WindowManager
+import androidx.annotation.ColorRes
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import com.silvertown.android.dailyphrase.presentation.R
 import com.silvertown.android.dailyphrase.presentation.databinding.FragmentBookmarkBinding
 import com.silvertown.android.dailyphrase.presentation.base.BaseFragment
-import com.silvertown.android.dailyphrase.presentation.ui.ActionType
 import com.silvertown.android.dailyphrase.presentation.ui.home.PostItemDecoration
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -90,6 +93,19 @@ class BookmarkFragment : BaseFragment<FragmentBookmarkBinding>(FragmentBookmarkB
 
     override fun onResume() {
         super.onResume()
+        setStatusBarColor(R.color.home_app_bar)
         viewModel.getBookmarks()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        setStatusBarColor(R.color.white)
+    }
+
+    private fun setStatusBarColor(@ColorRes colorRes: Int) {
+        activity?.window?.let { window ->
+            window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+            window.statusBarColor = ContextCompat.getColor(requireContext(), colorRes)
+        }
     }
 }

--- a/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/home/HomeFragment.kt
+++ b/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/home/HomeFragment.kt
@@ -2,9 +2,12 @@ package com.silvertown.android.dailyphrase.presentation.ui.home
 
 import android.os.Bundle
 import android.view.View
+import android.view.WindowManager
 import android.widget.Toast
+import androidx.annotation.ColorRes
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -163,4 +166,22 @@ class HomeFragment :
         viewModel.showLoginDialog(false)
         Toast.makeText(requireContext(), R.string.login_success_desc, Toast.LENGTH_SHORT).show()
     }
+
+    override fun onResume() {
+        super.onResume()
+        setStatusBarColor(R.color.home_app_bar)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        setStatusBarColor(R.color.white)
+    }
+
+    private fun setStatusBarColor(@ColorRes colorRes: Int) {
+        activity?.window?.let { window ->
+            window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+            window.statusBarColor = ContextCompat.getColor(requireContext(), colorRes)
+        }
+    }
+
 }

--- a/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/home/HomeFragment.kt
+++ b/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/home/HomeFragment.kt
@@ -172,8 +172,8 @@ class HomeFragment :
         setStatusBarColor(R.color.home_app_bar)
     }
 
-    override fun onPause() {
-        super.onPause()
+    override fun onStop() {
+        super.onStop()
         setStatusBarColor(R.color.white)
     }
 

--- a/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/home/PostAdapter.kt
+++ b/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/home/PostAdapter.kt
@@ -2,6 +2,8 @@ package com.silvertown.android.dailyphrase.presentation.ui.home
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.isGone
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
@@ -43,6 +45,7 @@ class PostAdapter(
                     post.isFavorite
                 )
             }
+            binding.clView.setOnClickListener { }
         }
 
         fun bind(post: Post) = with(binding) {
@@ -51,19 +54,31 @@ class PostAdapter(
             tvContent.text = post.content.replace("\n", " ")
             tvView.text = post.viewCount.formatNumberWithComma()
             tvLike.text = post.likeCount.formatNumberWithComma()
-            binding.ivImage.isGone = post.imageUrl.isEmpty()
+            tvBookmark.setTextColor(
+                if (post.isFavorite) {
+                    ContextCompat.getColor(itemView.context, R.color.black)
+                } else {
+                    ContextCompat.getColor(itemView.context, R.color.gray)
+                }
+            )
+            tvBookmark.typeface = if (post.isFavorite) {
+                ResourcesCompat.getFont(itemView.context, R.font.pretendard_medium)
+            } else {
+                ResourcesCompat.getFont(itemView.context, R.font.pretendard_regular)
+            }
+            ivImage.isGone = post.imageUrl.isEmpty()
 
             val bookmarkRes =
                 if (post.isFavorite) R.drawable.ic_bookmark_fill_60 else R.drawable.ic_bookmark_24
-            binding.ivBookmark.setImageResource(bookmarkRes)
+            ivBookmark.setImageResource(bookmarkRes)
 
             val likeRes = if (post.isLike) R.drawable.ic_like_fill_60 else R.drawable.ic_like_60
-            binding.ivLike.setImageResource(likeRes)
+            ivLike.setImageResource(likeRes)
 
             Glide.with(itemView)
                 .load(post.imageUrl)
                 .transform(CenterCrop(), RoundedCorners(16))
-                .into(binding.ivImage)
+                .into(ivImage)
         }
     }
 

--- a/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/home/PostAdapter.kt
+++ b/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/home/PostAdapter.kt
@@ -51,31 +51,46 @@ class PostAdapter(
 
         fun bind(post: Post) = with(binding) {
             this@PostViewHolder.post = post
+            val context = itemView.context
+
             tvTitle.text = post.title.replace("\n", " ")
             tvContent.text = post.content.replace("\n", " ")
             tvView.text = post.viewCount.formatNumberWithComma()
             tvLike.text = post.likeCount.formatNumberWithComma()
-            tvBookmark.setTextColor(
-                if (post.isFavorite) {
-                    ContextCompat.getColor(itemView.context, R.color.black)
-                } else {
-                    ContextCompat.getColor(itemView.context, R.color.gray)
-                }
-            )
-            tvBookmark.typeface = if (post.isFavorite) {
-                ResourcesCompat.getFont(itemView.context, R.font.pretendard_medium)
+
+            if (post.isFavorite) {
+                R.color.black
             } else {
-                ResourcesCompat.getFont(itemView.context, R.font.pretendard_regular)
+                R.color.gray
+            }.also { colorResId ->
+                tvBookmark.setTextColor(ContextCompat.getColor(context, colorResId))
             }
+
+            if (post.isFavorite) {
+                ResourcesCompat.getFont(context, R.font.pretendard_medium)
+            } else {
+                ResourcesCompat.getFont(context, R.font.pretendard_regular)
+            }.also { typeface ->
+                tvBookmark.typeface = typeface
+            }
+
+            if (post.isFavorite) {
+                R.drawable.ic_bookmark_fill_60
+            } else {
+                R.drawable.ic_bookmark_24
+            }.also { drawableRes ->
+                ivBookmark.setImageResource(drawableRes)
+            }
+
+            if (post.isLike) {
+                R.drawable.ic_like_fill_60
+            } else {
+                R.drawable.ic_like_60
+            }.also { drawableRes ->
+                ivLike.setImageResource(drawableRes)
+            }
+
             ivImage.isGone = post.imageUrl.isEmpty()
-
-            val bookmarkRes =
-                if (post.isFavorite) R.drawable.ic_bookmark_fill_60 else R.drawable.ic_bookmark_24
-            ivBookmark.setImageResource(bookmarkRes)
-
-            val likeRes = if (post.isLike) R.drawable.ic_like_fill_60 else R.drawable.ic_like_60
-            ivLike.setImageResource(likeRes)
-
             Glide.with(itemView)
                 .load(post.imageUrl)
                 .transform(CenterCrop(), RoundedCorners(16))

--- a/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/home/PostAdapter.kt
+++ b/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/home/PostAdapter.kt
@@ -45,6 +45,7 @@ class PostAdapter(
                     post.isFavorite
                 )
             }
+            // View 아이콘 클릭 시 root영역에 대한 클릭리스너와 중복을 피하기 위한 임시 리스너 활성
             binding.clView.setOnClickListener { }
         }
 

--- a/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/home/PostItemDecoration.kt
+++ b/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/home/PostItemDecoration.kt
@@ -10,7 +10,7 @@ import com.silvertown.android.dailyphrase.presentation.extensions.dpToPx
 class PostItemDecoration(val context: Context) : RecyclerView.ItemDecoration() {
     private val dividerHeight = 1.dpToPx(context)
     private val dividerMargin = 16.dpToPx(context)
-    private val headerMargin = 0.dpToPx(context)
+    private val headerMargin = 8.dpToPx(context)
     private val footerMargin = 16.dpToPx(context)
     private val dividerColor = 0xFFF2F3F6.toInt() // color.xml 생기면 수정
 
@@ -30,12 +30,18 @@ class PostItemDecoration(val context: Context) : RecyclerView.ItemDecoration() {
         val position = parent.getChildAdapterPosition(view)
         val itemCount = state.itemCount
 
-        if (position == 0) {
-            outRect.top = headerMargin
-        } else if (position == itemCount - 1) {
-            outRect.bottom = footerMargin
-        } else {
-            outRect.bottom = dividerHeight
+        when (position) {
+            0 -> {
+                outRect.top = headerMargin
+            }
+
+            itemCount - 1 -> {
+                outRect.bottom = footerMargin
+            }
+
+            else -> {
+                outRect.bottom = dividerHeight
+            }
         }
     }
 

--- a/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/mypage/MyPageScreen.kt
+++ b/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/mypage/MyPageScreen.kt
@@ -4,7 +4,6 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -150,7 +149,7 @@ private fun MyPageBody(
         ProfileContent(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(vertical = 16.dp),
+                .padding(top = 16.dp, bottom = 24.dp),
             userName = memberData.name,
             userProfile = memberData.imageUrl,
         )
@@ -211,7 +210,7 @@ fun MyPageItem(
         modifier = modifier
             .fillMaxWidth()
             .clickable { action() }
-            .padding(16.dp),
+            .padding(vertical = 14.dp, horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
@@ -225,9 +224,10 @@ fun MyPageItem(
             color = colorResource(id = R.color.black),
         )
         Icon(
-            modifier = Modifier.size(12.dp),
+            modifier = Modifier.size(24.dp),
             painter = painterResource(id = R.drawable.ic_arrow_forward_ios_24),
             contentDescription = null,
+            tint = colorResource(id = R.color.group_divider)
         )
     }
 }

--- a/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/mypage/non_login/NonLoginScreen.kt
+++ b/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/mypage/non_login/NonLoginScreen.kt
@@ -52,7 +52,9 @@ private fun Content(
         modifier = modifier,
         topBar = {
             BaseTopAppBar(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(28.dp),
                 navigateToBack = { navigateToBack() },
                 titleContent = {
                     Text(

--- a/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/mypage/unsubscribe/UnsubscribeScreen.kt
+++ b/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/mypage/unsubscribe/UnsubscribeScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.SnackbarHostState
@@ -95,7 +97,8 @@ private fun Content(
         snackbarHostState = snackbarHostState
     ) {
         UnsubscribeBody(
-            modifier = Modifier,
+            modifier = Modifier
+                .verticalScroll(rememberScrollState()),
             userName = getName() + stringResource(id = R.string.user_name_suffix),
             snackbarScope = snackbarScope,
             snackbarHostState = snackbarHostState,
@@ -127,14 +130,17 @@ private fun UnsubscribeBody(
     }
 
     Column(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .padding(bottom = 160.dp),
         verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Spacer(modifier = Modifier.height(20.dp))
         Text(
             modifier = Modifier
-                .fillMaxWidth(),
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
             text = userName + stringResource(id = R.string.message_before_leaving),
             style = TextStyle(
                 fontSize = 28.sp,
@@ -144,14 +150,12 @@ private fun UnsubscribeBody(
             color = colorResource(id = R.color.black),
             textAlign = TextAlign.Center
         )
+        Spacer(modifier = Modifier.height(52.dp))
 
-        Spacer(modifier = Modifier.height(30.dp))
         InfoMessageBox(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp)
         )
-
         Spacer(modifier = Modifier.height(80.dp))
 
         Text(
@@ -163,7 +167,7 @@ private fun UnsubscribeBody(
                 fontFamily = pretendardFamily,
                 fontWeight = FontWeight.SemiBold
             ),
-            color = colorResource(id = R.color.orange),
+            color = colorResource(id = R.color.orange_text),
             textDecoration = TextDecoration.Underline,
         )
     }
@@ -183,11 +187,7 @@ fun InfoMessageBox(
             titleId = R.string.unsubscribe_message_title_1,
             subtitleId = R.string.unsubscribe_message_subtitle_1
         )
-
-        ItemDivider(
-            modifier = Modifier.padding(40.dp)
-        )
-
+        Spacer(modifier = Modifier.height(40.dp))
         InfoMessageSection(
             iconId = R.drawable.ic_sad_60,
             titleId = R.string.unsubscribe_message_title_2,

--- a/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/mypage/unsubscribe/UnsubscribeViewModel.kt
+++ b/presentation/src/main/kotlin/com/silvertown/android/dailyphrase/presentation/ui/mypage/unsubscribe/UnsubscribeViewModel.kt
@@ -44,6 +44,7 @@ class UnsubscribeViewModel @Inject constructor(
         memberRepository
             .deleteMember()
             .onSuccess {
+                memberRepository.deleteAccessToken()
                 _isDeleted.emit(true)
             }
             .onFailure { errorMessage, code ->

--- a/presentation/src/main/res/drawable/ic_arrow_forward_ios_24.xml
+++ b/presentation/src/main/res/drawable/ic_arrow_forward_ios_24.xml
@@ -1,5 +1,4 @@
-<vector android:autoMirrored="true" android:height="24dp"
-    android:tint="#000000" android:viewportHeight="24"
-    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M6.23,20.23l1.77,1.77l10,-10l-10,-10l-1.77,1.77l8.23,8.23z"/>
+<vector android:height="24dp" android:viewportHeight="20"
+    android:viewportWidth="20" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#000000" android:pathData="M10.5,10L6.667,6.167L7.833,5L12.833,10L7.833,15L6.667,13.833L10.5,10Z"/>
 </vector>

--- a/presentation/src/main/res/layout/fragment_bookmark.xml
+++ b/presentation/src/main/res/layout/fragment_bookmark.xml
@@ -9,7 +9,10 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/cl_tool_bar"
         android:layout_width="0dp"
-        android:layout_height="64dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="4dp"
+        android:background="@color/home_app_bar"
+        android:paddingVertical="19dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
@@ -19,10 +22,12 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="20dp"
+            android:ellipsize="end"
             android:fontFamily="@font/pretendard_bold"
+            android:maxLines="2"
             android:text="@string/all_phrase"
             android:textColor="@color/light_gray"
-            android:textSize="22sp"
+            android:textSize="22dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -32,10 +37,13 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="20dp"
+            android:layout_marginEnd="20dp"
+            android:ellipsize="end"
             android:fontFamily="@font/pretendard_bold"
+            android:maxLines="2"
             android:text="@string/bookmark"
             android:textColor="@color/black"
-            android:textSize="22sp"
+            android:textSize="22dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toEndOf="@id/tv_all_phrase"
             app:layout_constraintTop_toTopOf="parent" />
@@ -44,12 +52,13 @@
             android:id="@+id/iv_profile"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="6dp"
-            android:padding="10dp"
+            android:paddingEnd="16dp"
             android:src="@drawable/ic_profile"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="@color/light_gray" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.recyclerview.widget.RecyclerView

--- a/presentation/src/main/res/layout/fragment_home.xml
+++ b/presentation/src/main/res/layout/fragment_home.xml
@@ -9,7 +9,10 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/cl_tool_bar"
         android:layout_width="0dp"
-        android:layout_height="64dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="4dp"
+        android:background="@color/home_app_bar"
+        android:paddingVertical="19dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
@@ -19,10 +22,12 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="20dp"
+            android:ellipsize="end"
             android:fontFamily="@font/pretendard_bold"
+            android:maxLines="2"
             android:text="@string/all_phrase"
             android:textColor="@color/black"
-            android:textSize="22sp"
+            android:textSize="22dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -32,10 +37,13 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="20dp"
+            android:layout_marginEnd="20dp"
+            android:ellipsize="end"
             android:fontFamily="@font/pretendard_bold"
+            android:maxLines="2"
             android:text="@string/bookmark"
             android:textColor="@color/light_gray"
-            android:textSize="22sp"
+            android:textSize="22dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toEndOf="@id/tv_all_phrase"
             app:layout_constraintTop_toTopOf="parent" />
@@ -44,12 +52,13 @@
             android:id="@+id/iv_profile"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="4dp"
-            android:padding="10dp"
+            android:paddingEnd="16dp"
             android:src="@drawable/ic_profile"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="@color/light_gray" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.recyclerview.widget.RecyclerView
@@ -68,7 +77,9 @@
     <androidx.compose.ui.platform.ComposeView
         android:id="@+id/compose_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        tools:layout_editor_absoluteX="0dp"
+        tools:layout_editor_absoluteY="0dp" />
 
     <LinearLayout
         android:id="@+id/load_state_layout"
@@ -89,9 +100,9 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="10dp"
             android:fontFamily="@font/pretendard_semi_bold"
+            android:gravity="center"
             android:text="@string/failure_load_message"
             android:textColor="@color/black"
-            android:gravity="center"
             android:textSize="18sp"
             android:textStyle="bold" />
 

--- a/presentation/src/main/res/values/colors.xml
+++ b/presentation/src/main/res/values/colors.xml
@@ -7,8 +7,11 @@
     <color name="gray">#FF64696B</color>
     <color name="divider">#F2F3F6</color>
     <color name="orange">#FF7900</color>
+    <color name="orange_text">#EF8031</color>
     <color name="yellow">#FFF7E04C</color>
     <color name="kakao_container">#FEE500</color>
     <color name="kakao_text">#191919</color>
     <color name="snackbar_text">#FFEF8031</color>
+    <color name="group_divider">#64696B</color>
+    <color name="home_app_bar">#F4F1EA</color>
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -20,7 +20,7 @@
     <string name="unsubscribe_message_title_2">소중한 사람들에게\n글귀를 공유할 수가 없어요.</string>
     <string name="unsubscribe_message_subtitle_2">글귀를 공유하기 위해서는 로그인이 필요해요.</string>
     <string name="confirm_unsubscribe_service">그래도 탈퇴할게요.</string>
-    <string name="user_name_suffix">"님,\n"</string>
+    <string name="user_name_suffix">"님\n"</string>
     <string name="default_view_count">0</string>
     <string name="default_like_count">0</string>
     <string name="all_phrase">모든 글귀</string>


### PR DESCRIPTION
1. 디바이스 Protrait로 고정
2. 액세스토큰 문제 -> 멤버를 지우는 @DELETE API 요청을 보낼 때 로컬에 저장된 액세스토큰을 담아서 Bearer $AccessToken으로 던지는데, 이때 DELETE API 요청을 하기 전에 로컬에서 먼저 AccessToken을 지워서 Bearer null로 보내기 때문에 로직의 순서 상 문제가 있었음. -> @DELETE 요청 후 로컬에 저장된 AccessToken을 지우는 것으로 로직 변경
3. 그 외 전반적인 디자인 변경